### PR TITLE
Fix monitorRequestList sort

### DIFF
--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -101,9 +101,9 @@ func (m *Monitor) workerProcessRequest(request *monitorRequest, rpcClient *ethcl
 	receipt, err := rpcClient.TransactionReceipt(context.Background(), common.HexToHash(request.l2Tx.Hash))
 	if err != nil {
 		if !errors.Is(err, ethereum.NotFound) {
-			log.Errorf("monitor-worker[%03d]: error getting receipt for tx %s, schedule retry, error: %v", workerNum, request.l2Tx.Tag, err)
+			log.Errorf("monitor-worker[%03d]: error getting receipt for tx %s, schedule retry, error: %v", workerNum, request.l2Tx.Tag(), err)
 		} else {
-			log.Debugf("monitor-worker[%03d]: receipt for tx %s still not available, schedule retry", workerNum, request.l2Tx.Tag)
+			log.Debugf("monitor-worker[%03d]: receipt for tx %s still not available, schedule retry", workerNum, request.l2Tx.Tag())
 		}
 		m.scheduleRequestRetry(request)
 	} else {

--- a/monitor/request_list.go
+++ b/monitor/request_list.go
@@ -125,12 +125,12 @@ func (e *monitorRequestList) addSort(request *monitorRequest) {
 
 // isGreaterThan returns true if the request1 has greater nextRetry time than request2
 func (e *monitorRequestList) isGreaterThan(request1 *monitorRequest, request2 *monitorRequest) bool {
-	return request1.nextRetry.After(request2.nextRetry)
+	return request1.nextRetry.UnixMilli() > request2.nextRetry.UnixMilli()
 }
 
 // isGreaterOrEqualThan returns true if the request1 has greater or equal nextRetry time than request2
 func (e *monitorRequestList) isGreaterOrEqualThan(request1 *monitorRequest, request2 *monitorRequest) bool {
-	return (request1.nextRetry.After(request2.nextRetry)) || (request1.nextRetry == request2.nextRetry)
+	return request1.nextRetry.UnixMilli() >= request2.nextRetry.UnixMilli()
 }
 
 // GetSorted returns the sorted list of monitor requests

--- a/monitor/request_list.go
+++ b/monitor/request_list.go
@@ -44,7 +44,7 @@ func (e *monitorRequestList) delete(request *monitorRequest) bool {
 	if request, found := e.list[request.l2Tx.Hash]; found {
 		sLen := len(e.sorted)
 		i := sort.Search(sLen, func(i int) bool {
-			return e.isGreaterOrEqualThan(request, e.list[e.sorted[i].l2Tx.Hash])
+			return e.isGreaterOrEqualThan(e.list[e.sorted[i].l2Tx.Hash], request)
 		})
 
 		// i is the index of the first tx that has equal (or lower) nextRetry time than the request. From here we need to go down in the list
@@ -58,7 +58,7 @@ func (e *monitorRequestList) delete(request *monitorRequest) bool {
 
 			if e.sorted[i].nextRetry != request.nextRetry {
 				// we have a request with different (lower) nextRetry time than the request we are looking for, therefore we haven't found the request
-				log.Warnf("error deleting monitor request %s from monitoreRequestList, not found in the list of requests with same nextRetry time: %s", request.l2Tx.Hash)
+				log.Warnf("error deleting monitor request %s from monitoreRequestList, not found in the list of requests with same nextRetry time: %v", request.l2Tx.Hash, request.nextRetry)
 				return false
 			}
 
@@ -114,7 +114,7 @@ func (e *monitorRequestList) Print() {
 // addSort adds the monitor request to the list in a sorted way
 func (e *monitorRequestList) addSort(request *monitorRequest) {
 	i := sort.Search(len(e.sorted), func(i int) bool {
-		return e.isGreaterThan(request, e.list[e.sorted[i].l2Tx.Hash])
+		return e.isGreaterThan(e.list[e.sorted[i].l2Tx.Hash], request)
 	})
 
 	e.sorted = append(e.sorted, nil)

--- a/monitor/request_list_test.go
+++ b/monitor/request_list_test.go
@@ -1,0 +1,66 @@
+package monitor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/0xPolygonHermez/zkevm-pool-manager/types"
+)
+
+func TestRequestListDelete(t *testing.T) {
+	el := newMonitorRequestList()
+
+	now := time.Now()
+	past := now.Add(-time.Minute * 5)
+	future := now.Add(time.Minute * 5)
+
+	el.add(&monitorRequest{
+		l2Tx:      types.L2Transaction{Id: 1, Hash: "0x01"},
+		nextRetry: now,
+	})
+	el.add(&monitorRequest{
+		l2Tx:      types.L2Transaction{Id: 2, Hash: "0x02"},
+		nextRetry: now,
+	})
+	el.add(&monitorRequest{
+		l2Tx:      types.L2Transaction{Id: 3, Hash: "0x03"},
+		nextRetry: past,
+	})
+	el.add(&monitorRequest{
+		l2Tx:      types.L2Transaction{Id: 4, Hash: "0x04"},
+		nextRetry: past,
+	})
+	el.add(&monitorRequest{
+		l2Tx:      types.L2Transaction{Id: 5, Hash: "0x05"},
+		nextRetry: future,
+	})
+
+	sort := []string{"0x03", "0x04", "0x01", "0x02", "0x05"}
+
+	for index, req := range el.sorted {
+		if sort[index] != req.l2Tx.Hash {
+			t.Fatalf("Sort error. Expected %s, Actual %s", sort[index], req.l2Tx.Hash)
+		}
+	}
+
+	delreqs := []string{"0x01", "0x04", "0x05"}
+
+	for _, delreq := range delreqs {
+		count := el.len()
+		el.delete(&monitorRequest{l2Tx: types.L2Transaction{Hash: delreq}})
+
+		for i := 0; i < el.len(); i++ {
+			if el.getByIndex(i).l2Tx.Hash == delreq {
+				t.Fatalf("Delete error. %s req was not deleted", delreq)
+			}
+		}
+
+		if el.len() != count-1 {
+			t.Fatalf("Length error. Length %d. Expected %d", el.len(), count)
+		}
+	}
+
+	if el.delete(&monitorRequest{l2Tx: types.L2Transaction{Hash: "0x05"}}) {
+		t.Fatal("Delete error. 0x05 req was deleted and should not exist in the list")
+	}
+}


### PR DESCRIPTION
The monitorRequestList object was sorting the items (requests) in the inverse order. It should sort the monitorRequest by nextRetry field in ascendent order and it was doing in the descendent order and that was wrong. This could cause some problems when trying to delete a request if there are others requests with the same nextRetry time. Also this error could cause some minor issues when monitoring tx to get the receipt, since the monitoring was prioritizing the most recent transactions compared to the old ones