### PR TITLE
feat: do not return error on GetSender

### DIFF
--- a/server/endpoints.go
+++ b/server/endpoints.go
@@ -50,8 +50,8 @@ func (e *Endpoints) SendRawTransaction(httpRequest *http.Request, input string) 
 	// Get from address
 	fromAddress, err := GetSender(*tx)
 	if err != nil {
-		log.Errorf("error getting from address for tx %s, error: %v", tx.Hash(), err)
-		return nil, NewServerErrorWithData(ParserErrorCode, "error getting from address", nil)
+		log.Warnf("error getting from address for tx %s, error: %v", tx.Hash(), err)
+		fromAddress = common.Address{}
 	}
 
 	log.Debugf("adding tx %s to the pool", tx.Hash())

--- a/server/endpoints.go
+++ b/server/endpoints.go
@@ -51,7 +51,6 @@ func (e *Endpoints) SendRawTransaction(httpRequest *http.Request, input string) 
 	fromAddress, err := GetSender(*tx)
 	if err != nil {
 		log.Warnf("error getting from address for tx %s, error: %v", tx.Hash(), err)
-		fromAddress = common.Address{}
 	}
 
 	log.Debugf("adding tx %s to the pool", tx.Hash())


### PR DESCRIPTION
Do not return error if sender can not been retrieved from the tx.