### PR TITLE
optimize http connection multiplexing

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -32,6 +32,8 @@ ResendTxsCheckInterval = "5s"
 Workers = 5
 QueueSize = 25
 RPCReadTimeout = "3s"
+DailTimeout = "30s"
+KeepAlive = "120s"
 
 [Monitor]
 L2NodeURL = "http://localhost:8467"
@@ -41,4 +43,6 @@ RetryWaitInterval = "3s"
 InitialWaitInterval = "3s"
 TxLifeTimeMax = "30m"
 RPCReadTimeout = "3s"
+DailTimeout = "30s"
+KeepAlive = "120s"
 `

--- a/monitor/config.go
+++ b/monitor/config.go
@@ -1,6 +1,8 @@
 package monitor
 
-import "github.com/0xPolygonHermez/zkevm-pool-manager/config/types"
+import (
+	"github.com/0xPolygonHermez/zkevm-pool-manager/config/types"
+)
 
 // Config for pool-manager monitor
 type Config struct {
@@ -24,4 +26,10 @@ type Config struct {
 
 	// RPCReadTimeout is the timeout for the RPC client to read the response from the L2 node
 	RPCReadTimeout types.Duration `mapstructure:"RPCReadTimeout"`
+
+	// DialTimeout is the maximum amount of time a dial will wait for a connect to complete.
+	DialTimeout types.Duration `mapstructure:"DailTimeout"`
+
+	// KeepAlive specifies the interval between keep-alive probes for an active network connection.
+	KeepAlive types.Duration `mapstructure:"KeepAlive"`
 }

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -3,6 +3,8 @@ package monitor
 import (
 	"context"
 	"errors"
+	"net"
+	"net/http"
 	"sync"
 	"time"
 
@@ -11,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
 )
 
 type Monitor struct {
@@ -68,12 +71,20 @@ func (m *Monitor) enqueueMonitorRequest(request *monitorRequest) {
 }
 
 func (m *Monitor) startMonitorWorker(workerNum int) {
-	rpcClient, err := ethclient.Dial(m.cfg.L2NodeURL)
-
+	httpClient := rpc.WithHTTPClient(&http.Client{
+		Transport: &http.Transport{
+			DialContext: (&net.Dialer{
+				Timeout:   m.cfg.DialTimeout.Duration,
+				KeepAlive: m.cfg.KeepAlive.Duration,
+			}).DialContext,
+		},
+	})
+	rclient, err := rpc.DialOptions(context.Background(), m.cfg.L2NodeURL, httpClient)
 	if err != nil {
 		log.Errorf("monitor-worker[%03d]: error creating rpc client for %s, err: %v", workerNum, m.cfg.L2NodeURL, err)
 		return
 	}
+	rpcClient := ethclient.NewClient(rclient)
 
 	log.Debugf("monitor-worker[%03d]: started", workerNum)
 	for monitorRequest := range m.requestChan {

--- a/sender/config.go
+++ b/sender/config.go
@@ -1,6 +1,8 @@
 package sender
 
-import "github.com/0xPolygonHermez/zkevm-pool-manager/config/types"
+import (
+	"github.com/0xPolygonHermez/zkevm-pool-manager/config/types"
+)
 
 // Config for pool-manager sender
 type Config struct {
@@ -18,4 +20,10 @@ type Config struct {
 
 	// RPCReadTimeout is the timeout for the RPC client to read the response from the L2 node
 	RPCReadTimeout types.Duration `mapstructure:"RPCReadTimeout"`
+
+	// DialTimeout is the maximum amount of time a dial will wait for a connect to complete.
+	DialTimeout types.Duration `mapstructure:"DailTimeout"`
+
+	// KeepAlive specifies the interval between keep-alive probes for an active network connection.
+	KeepAlive types.Duration `mapstructure:"KeepAlive"`
 }

--- a/sender/sender.go
+++ b/sender/sender.go
@@ -2,12 +2,15 @@ package sender
 
 import (
 	"context"
+	"net"
+	"net/http"
 	"sync"
 	"time"
 
 	"github.com/0xPolygonHermez/zkevm-pool-manager/log"
 	"github.com/0xPolygonHermez/zkevm-pool-manager/types"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/jackc/pgx/v4"
 )
 
@@ -78,12 +81,21 @@ func (s *Sender) enqueueSenderRequest(request *sendRequest) {
 }
 
 func (s *Sender) startSenderWorker(workerNum int) {
-	seqClient, err := ethclient.Dial(s.cfg.SequencerURL)
 
+	httpClient := rpc.WithHTTPClient(&http.Client{
+		Transport: &http.Transport{
+			DialContext: (&net.Dialer{
+				Timeout:   s.cfg.DialTimeout.Duration,
+				KeepAlive: s.cfg.KeepAlive.Duration,
+			}).DialContext,
+		},
+	})
+	rclient, err := rpc.DialOptions(context.Background(), s.cfg.SequencerURL, httpClient)
 	if err != nil {
 		log.Errorf("sender-worker[%03d]: error creating sequencer client for %s, err: %v", workerNum, s.cfg.SequencerURL, err)
 		return
 	}
+	seqClient := ethclient.NewClient(rclient)
 
 	log.Debugf("sender-worker[%03d]: started", workerNum)
 	for sendRequest := range s.requestChan {


### PR DESCRIPTION
This feature can make the http multiplexing connection, because the ` zkevm-pool-manager` is a sever, a large number tx make need a lot of port.

This is log beacuse of send a large number tx to `zkevm-pool-manager` ,it will have a error:
```
2025-03-20T03:44:29.651Z	[34mINFO[0m	server/endpoints.go:78	sending tx [40649]:0x94ef87e24ec1901c43282001ef561d50b6e351ebbb5dbed88be06fcd20f00464 to sequencer returns error: Post "http://erigon-seq:8123": dial tcp 172.21.0.9:8123: connect: cannot assign requested address	{"pid": 1, "version": "v0.1.2"}
```

shell for statistics on the number of connection ports  :
```
watch -n 1 "ss -atn | grep 8123 | wc -l"
```
this is the develop branch statistics :
![15](https://github.com/user-attachments/assets/5a656e33-f96a-4f32-be10-e8a798221acb)


this is this pr statistics 
![16](https://github.com/user-attachments/assets/bdebbcb0-37d4-4249-829c-d0f40b644270)

