### PR TITLE
Add TX Pool Mgr retransmission mechanism during Seq failover 

### DIFF
--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -108,7 +108,10 @@ func (m *Monitor) workerProcessRequest(request *monitorRequest, rpcClient *ethcl
 		} else {
 			log.Debugf("monitor-worker[%03d]: receipt for tx %s still not available, schedule retry", workerNum, request.l2Tx.Tag())
 		}
-		m.scheduleRequestRetry(request)
+		// For resend tx
+		if !m.tryResendTx(ctx, rpcClient, request, workerNum) {
+			m.scheduleRequestRetry(request)
+		}
 	} else {
 		l2TxStatus := types.TxStatusConfirmed
 		if receipt.Status == 0 {
@@ -167,4 +170,19 @@ func (m *Monitor) monitorL2TransactionsFromPoolDB() {
 	for _, l2Tx := range l2Txs {
 		m.AddL2Transaction(l2Tx)
 	}
+}
+
+func (m *Monitor) tryResendTx(ctx context.Context, rpcClient *ethclient.Client, request *monitorRequest, workerNum int) bool {
+	_, _, err := rpcClient.TransactionByHash(ctx, common.HexToHash(request.l2Tx.Hash))
+	if !errors.Is(err, ethereum.NotFound) {
+		return false
+	}
+	log.Warnf("monitor-worker[%03d], getting tx by hash not found! %s, error: %v", workerNum, request.l2Tx.Tag(), err)
+	err = m.poolDB.UpdateL2TransactionStatus(context.Background(), request.l2Tx.Id, types.TxStatusResend, "")
+	if err != nil {
+		log.Errorf("error updating tx %s status (%s) in the pool db, error: %v", request.l2Tx.Tag(), types.TxStatusSent, err)
+		return false
+	}
+
+	return true
 }

--- a/sender/sender.go
+++ b/sender/sender.go
@@ -2,6 +2,7 @@ package sender
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"time"
 
@@ -116,11 +117,20 @@ func (s *Sender) checkL2TransactionsToResend() {
 		}
 
 		for _, l2Tx := range txs {
+			txTag := l2Tx.Tag()
 			err := s.SendL2Transaction(l2Tx)
 			if err != nil {
 				log.Infof("resending tx %s to sequencer returns error: %v", l2Tx.Tag(), err)
+				// For resend tx
+				if s.checkNeedResendError(txTag, err) {
+					log.Warnf("error sending tx %s to sequencer, connection refused, will change to resend again", txTag)
+					err = s.poolDB.UpdateL2TransactionStatus(context.Background(), l2Tx.Id, types.TxStatusResend, "")
+					if err != nil {
+						log.Errorf("resending error, updating tx %s status (%s) in the pool db, error: %v", txTag, types.TxStatusSent, err)
+					}
+				}
 			} else {
-				log.Infof("tx %s resent to sequencer", l2Tx.Tag())
+				log.Infof("tx %s resent to sequencer", txTag)
 			}
 		}
 
@@ -144,4 +154,18 @@ func (s *Sender) sendL2TransactionsFromPoolDB() {
 			log.Infof("tx %s sent to sequencer", l2Tx.Tag())
 		}
 	}
+}
+
+func (s *Sender) checkNeedResendError(txTag string, err error) bool {
+	if err == nil {
+		return false
+	}
+	log.Infof("checkNeedResendError:%v, %v", txTag, err)
+	if strings.Contains(err.Error(), "connection refused") ||
+		strings.Contains(err.Error(), "EOF") ||
+		strings.Contains(err.Error(), "deadline exceeded") ||
+		strings.Contains(err.Error(), "no such host") {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
### Background:
The tx pool mgr service already contains retransmission-related code, but it has not been fully implemented yet.

### Problem:
When Seq encounters an exception (e.g., crash, restart) or switches to a backup Seq instance, transactions currently in the transaction pool may be lost.

### Proposal:

Complete the implementation of the tx pool mgr retransmission mechanism.

Ensure that during Seq startup failures or backup Seq switching, the retransmission mechanism is triggered to check and resend pending transactions, preventing transaction loss.

